### PR TITLE
added empty alt attribute to created images

### DIFF
--- a/src/playback.sjs
+++ b/src/playback.sjs
@@ -11,6 +11,7 @@ function addClasses(element, frame) {
 var createImage = function (frame) {
     var image = new Image();
     image.src = frame.url;
+    image.alt = '';
     addClasses(image, frame);
     return image;
   };


### PR DESCRIPTION
Whilst not really an issue yet, any image element without an alt attribute can really be annoying for assistive technology. An empty alt at least makes for example a screen reader not read out the "blob:" urls. 
