### PR TITLE
Blocksize fix feature

### DIFF
--- a/dist/x-gif.js
+++ b/dist/x-gif.js
@@ -87,7 +87,6 @@ Exploder.prototype.explode = function (buffer) {
         streamReader.log("LOCAL COLOR TABLE");
         var colorTableSize = streamReader.readByte() & 0x07;
         streamReader.log("LOCAL COLOR TABLE IS " + 3 * Math.pow(2, colorTableSize + 1) + " BYTES")
-        streamReader.skipBytes(2);
         streamReader.skipBytes(3 * Math.pow(2, colorTableSize + 1));
       } else {
         streamReader.log("NO LOCAL TABLE PHEW");

--- a/src/exploder.js
+++ b/src/exploder.js
@@ -86,7 +86,6 @@ Exploder.prototype.explode = function (buffer) {
         streamReader.log("LOCAL COLOR TABLE");
         var colorTableSize = streamReader.readByte() & 0x07;
         streamReader.log("LOCAL COLOR TABLE IS " + 3 * Math.pow(2, colorTableSize + 1) + " BYTES")
-        streamReader.skipBytes(2);
         streamReader.skipBytes(3 * Math.pow(2, colorTableSize + 1));
       } else {
         streamReader.log("NO LOCAL TABLE PHEW");


### PR DESCRIPTION
When I was using the x-gif, some frames were not parsed correctly.
I was corrected this =)

Please check it outputs the blockSize! (src/exploder.js 100th line)

Reference of gif format
http://www.onicos.com/staff/iz/formats/gif.html
