### PR TITLE
[Accessibility] Make frames invisible for screen readers

### DIFF
--- a/src/playback.js
+++ b/src/playback.js
@@ -8,6 +8,7 @@ function addClasses(element, frame) {
 var createImage = function (frame) {
   var image = new Image();
   image.src = frame.url;
+  image.setAttribute('alt', '');
   addClasses(image, frame);
   return image;
 };

--- a/src/x-gif.angular.js
+++ b/src/x-gif.angular.js
@@ -8,7 +8,7 @@ angular.module('x-gif', [])
   .directive('gif', function () {
     return {
       restrict: 'E',
-      template: '<div class="frames-wrapper"><div class="x-gif__frames"></div></div>',
+      template: '<div class="frames-wrapper" role="presentation"><div class="x-gif__frames"></div></div>',
       link: function (scope, element, attrs) {
         var xGif = Object.create(attrs, {
           fire: {

--- a/src/x-gif.html
+++ b/src/x-gif.html
@@ -1,6 +1,6 @@
 <template id="template">
   <link rel="stylesheet" href="x-gif.css"/>
-  <div class="frames-wrapper">
+  <div class="frames-wrapper" role="presentation">
     <div id="frames"></div>
   </div>
 </template>


### PR DESCRIPTION
The most important issue to solve is to hide images from screen readers, solved by:
- empty ALT,
- role="presentation" on frames container.

We don’t need to force labels for every gif image, as most of them will have blank alternative text for sure.
