### PR TITLE
add polymer.js to handle unresolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bower_components
 node_modules
+.sass_cache
 demos/audio
 dist/images
 /*.gif

--- a/demos/basic.html
+++ b/demos/basic.html
@@ -3,6 +3,7 @@
   <head>
     <title>Toggle Button</title>
     <script src="../dist/platform.js"></script>
+    <script src="../dist/polymer.js"></script>
     <link rel="import" href="../dist/x-gif.html">
     <style>
       body > * { display: block; }


### PR DESCRIPTION
Looks like `polymer.js` has to be in the demo files to do the polyfill to handle the unresolved attribute in `<body unresolved>`. This adds it to `demos/basic.html`, looks like others might need it too?

I tested this on Chrome 40 on Mac OS 10.10.

IDK however if the polymer code should be included in platform.js or if some other approach should be taken?

(Also, ".sass_cache" showed up in my project after setting things up, so I added it to .gitignore)
