### PR TITLE
Use protocol-relative links for imgur gifs

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,12 +188,12 @@
   angular.module('x-gif-demo', [])
     .controller('DemoCtrl', function ($scope, $sce, $location, $http) {
       $scope.gifs = [
-        "http://i.imgur.com/iKXH4E2.gif",
-        "http://i.imgur.com/RY2vTBQ.gif",
-        "http://i.imgur.com/YlxOOI7.gif",
-        "http://i.imgur.com/5KSc0px.gif",
-        "http://i.imgur.com/m25uYzq.gif",
-        "http://i.imgur.com/ifR7csn.gif"
+        "//i.imgur.com/iKXH4E2.gif",
+        "//i.imgur.com/RY2vTBQ.gif",
+        "//i.imgur.com/YlxOOI7.gif",
+        "//i.imgur.com/5KSc0px.gif",
+        "//i.imgur.com/m25uYzq.gif",
+        "//i.imgur.com/ifR7csn.gif"
       ];
       $scope.gif = {
         url: $scope.gifs[0],


### PR DESCRIPTION
Using the [HTTPS Everywhere](https://www.eff.org/https-everywhere) Chrome extension, the example gifs on x-gif's [homepage](https://geleen.github.io/x-gif) are not loaded because they are explicitly loaded over `http://`. This pull request changes those gifs to use protocol-relative URLs so they can be loaded over a secured connection, if the visitor asks for one.
